### PR TITLE
Attempt to get boundary geohashes to line up with PostGIS ST_GeoHash and geohash.org

### DIFF
--- a/src/main/java/com/github/davidmoten/geo/GeoHash.java
+++ b/src/main/java/com/github/davidmoten/geo/GeoHash.java
@@ -367,14 +367,14 @@ public final class GeoHash {
         while (geohash.length() < length) {
             if (isEven) {
                 double mid = (lon[0] + lon[1]) / 2;
-                if (longitude > mid) {
+                if (longitude >= mid) {
                     ch |= BITS[bit];
                     lon[0] = mid;
                 } else
                     lon[1] = mid;
             } else {
                 double mid = (lat[0] + lat[1]) / 2;
-                if (latitude > mid) {
+                if (latitude >= mid) {
                     ch |= BITS[bit];
                     lat[0] = mid;
                 } else

--- a/src/test/java/com/github/davidmoten/geo/CoverageTest.java
+++ b/src/test/java/com/github/davidmoten/geo/CoverageTest.java
@@ -26,6 +26,6 @@ public class CoverageTest {
     public void testCoverageOfAnAreaThatCantBeCoveredWithHashOfLengthOne() {
         Coverage coverage = GeoHash.coverBoundingBox(-5, 100, -45, 170);
         assertEquals(1, coverage.getHashLength());
-        assertEquals(Sets.newHashSet("n", "p", "q", "r"), coverage.getHashes());
+        assertEquals(Sets.newHashSet("q", "r"), coverage.getHashes());
     }
 }

--- a/src/test/java/com/github/davidmoten/geo/GeoHashTest.java
+++ b/src/test/java/com/github/davidmoten/geo/GeoHashTest.java
@@ -27,6 +27,7 @@ import java.util.TreeSet;
 import org.junit.Test;
 
 import com.google.common.collect.Sets;
+import java.util.List;
 
 /**
  * Unit tests for {@link GeoHash}.
@@ -41,6 +42,15 @@ public class GeoHashTest {
     private static final double SCHENECTADY_LON = -73.950691;
     private static final double SCHENECTADY_LAT = 42.819581;
     private static final double PRECISION = 0.000000001;
+    private static final int I_LEFT      = 0;
+    private static final int I_RIGHT     = 1;
+    private static final int I_TOP       = 2;
+    private static final int I_BOTTOM    = 3;
+    private static final int I_LEFT_TOP  = 4;
+    private static final int I_LEFT_BOT  = 5;
+    private static final int I_RIGHT_TOP = 6;
+    private static final int I_RIGHT_BOT = 7;
+    
 
     @Test
     public void getCoverageOfPrivateConstructor() {
@@ -468,38 +478,90 @@ public class GeoHashTest {
     @Test
     public void testTopNeighbourCloseToNorthPole() {
         String hash = GeoHash.encodeHash(90, 0, 1);
-        assertEquals("z", GeoHash.adjacentHash(hash, Direction.TOP));
+        assertEquals("u", hash);
+        assertEquals("b", GeoHash.adjacentHash(hash, Direction.TOP));
     }
 
     @Test
     public void testBottomNeighbourCloseToSouthPole() {
         String hash = GeoHash.encodeHash(-90, 0, 1);
-        System.out.println(hash);
-        assertEquals("p", GeoHash.adjacentHash(hash, Direction.BOTTOM));
+        assertEquals("h", hash);
+        assertEquals("0", GeoHash.adjacentHash(hash, Direction.BOTTOM));
     }
 
+    // Nice map here at poles
+    // http://www.bigdatamodeling.org/2013/01/intuitive-geohash.html
     @Test
     public void testNeighboursAtSouthPole() {
-        // TODO write asserts
-        System.out.println(GeoHash.neighbours(GeoHash.encodeHash(-90, 0)));
+        String poleHash = GeoHash.encodeHash(-90, 0);
+        assertEquals("h00000000000", poleHash);
+
+        List<String> neighbors = GeoHash.neighbours(poleHash);
+        assertEquals(8, neighbors.size());
+
+        assertEquals("5bpbpbpbpbpb", neighbors.get(I_LEFT));
+        assertEquals("h00000000002", neighbors.get(I_RIGHT));
+        assertEquals("h00000000001", neighbors.get(I_TOP));
+        assertEquals("00000000000p", neighbors.get(I_BOTTOM));
+        assertEquals("5bpbpbpbpbpc", neighbors.get(I_LEFT_TOP));
+        assertEquals("pbpbpbpbpbpz", neighbors.get(I_LEFT_BOT));
+        assertEquals("h00000000003", neighbors.get(I_RIGHT_TOP));
+        assertEquals("00000000000r", neighbors.get(I_RIGHT_BOT));
     }
 
     @Test
     public void testNeighboursAtNorthPole() {
-        // TODO write asserts
-        System.out.println(GeoHash.neighbours(GeoHash.encodeHash(90, 0)));
+        String poleHash = GeoHash.encodeHash(90, 0);
+        assertEquals("upbpbpbpbpbp", poleHash);
+        
+        List<String> neighbors = GeoHash.neighbours(poleHash);
+        assertEquals(8, neighbors.size());
+
+        assertEquals("gzzzzzzzzzzz", neighbors.get(I_LEFT));
+        assertEquals("upbpbpbpbpbr", neighbors.get(I_RIGHT));
+        assertEquals("bpbpbpbpbpb0", neighbors.get(I_TOP));
+        assertEquals("upbpbpbpbpbn", neighbors.get(I_BOTTOM));
+        assertEquals("zzzzzzzzzzzb", neighbors.get(I_LEFT_TOP));
+        assertEquals("gzzzzzzzzzzy", neighbors.get(I_LEFT_BOT));
+        assertEquals("bpbpbpbpbpb2", neighbors.get(I_RIGHT_TOP));
+        assertEquals("upbpbpbpbpbq", neighbors.get(I_RIGHT_BOT));
     }
 
     @Test
     public void testNeighboursAtLongitude180() {
-        // TODO write asserts
-        System.out.println(GeoHash.neighbours(GeoHash.encodeHash(0, 180)));
+        String hash = GeoHash.encodeHash(0, 180);
+        assertEquals("xbpbpbpbpbpb", hash);
+        
+        List<String> neighbors = GeoHash.neighbours(hash);
+        assertEquals(8, neighbors.size());
+
+        assertEquals("xbpbpbpbpbp8", neighbors.get(I_LEFT));
+        assertEquals("800000000000", neighbors.get(I_RIGHT));
+        assertEquals("xbpbpbpbpbpc", neighbors.get(I_TOP));
+        assertEquals("rzzzzzzzzzzz", neighbors.get(I_BOTTOM));
+        assertEquals("xbpbpbpbpbp9", neighbors.get(I_LEFT_TOP));
+        assertEquals("rzzzzzzzzzzx", neighbors.get(I_LEFT_BOT));
+        assertEquals("800000000001", neighbors.get(I_RIGHT_TOP));
+        assertEquals("2pbpbpbpbpbp", neighbors.get(I_RIGHT_BOT));
     }
 
     @Test
     public void testNeighboursAtLongitudeMinus180() {
-        // TODO write asserts
-        System.out.println(GeoHash.neighbours(GeoHash.encodeHash(0, -180)));
+        String hash = GeoHash.encodeHash(0, -180);
+        assertEquals("800000000000", hash);
+        
+        List<String> neighbors = GeoHash.neighbours(hash);
+        System.out.println(neighbors);
+        assertEquals(8, neighbors.size());
+
+        assertEquals("xbpbpbpbpbpb", neighbors.get(I_LEFT));
+        assertEquals("800000000002", neighbors.get(I_RIGHT));
+        assertEquals("800000000001", neighbors.get(I_TOP));
+        assertEquals("2pbpbpbpbpbp", neighbors.get(I_BOTTOM));
+        assertEquals("xbpbpbpbpbpc", neighbors.get(I_LEFT_TOP));
+        assertEquals("rzzzzzzzzzzz", neighbors.get(I_LEFT_BOT));
+        assertEquals("800000000003", neighbors.get(I_RIGHT_TOP));
+        assertEquals("2pbpbpbpbpbr", neighbors.get(I_RIGHT_BOT));
     }
 
 }


### PR DESCRIPTION
At lat/lon 0,0 the output of geohash should be s00000000000 to match geohash.org and PostGIS ST_GeoHash function.

```
=> select ST_GeoHash(ST_SetSRID(ST_MakePoint(0,0),4326),12);
  st_geohash  
 s00000000000
```

Similar issue was fixed in PostGIS to match geohash.org:
Reference: http://trac.osgeo.org/postgis/ticket/2201

Also:
Add asserts for hashes around boundary/pole conditions.
