### PR TITLE
Arrays.copyOf is only available since Android 2.3

### DIFF
--- a/src/main/java/com/github/davidmoten/geo/CoverageLongs.java
+++ b/src/main/java/com/github/davidmoten/geo/CoverageLongs.java
@@ -45,7 +45,9 @@ class CoverageLongs {
      * @return set of hashes
      */
     public long[] getHashes() {
-        return Arrays.copyOf(hashes, count);
+        long[] res = new long[count];
+        System.arraycopy(hashes, 0, res, 0, count);
+        return res;
     }
 
     /**

--- a/src/main/java/com/github/davidmoten/geo/GeoHash.java
+++ b/src/main/java/com/github/davidmoten/geo/GeoHash.java
@@ -626,8 +626,11 @@ public final class GeoHash {
 			for(int i = 0 ; i < count ; i++)
 				if(array[i] == l)
 					return;
-			if(count == cap)
-				array = Arrays.copyOf(array, cap*=2);
+			if(count == cap) {
+				long[] newArray = new long[cap*=2];
+				System.arraycopy(array, 0, newArray, 0, count);
+				array = newArray;
+			}
 			array[count++] = l;
 		}
 	}


### PR DESCRIPTION
No need to break compatibility with Froyo and earlier, specially if it is so easy.

Thanks!