### PR TITLE
Fix wrong coverage around antimeridian

### DIFF
--- a/geo/src/test/java/com/github/davidmoten/geo/CoverageTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/CoverageTest.java
@@ -1,6 +1,7 @@
 package com.github.davidmoten.geo;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -27,5 +28,85 @@ public class CoverageTest {
         Coverage coverage = GeoHash.coverBoundingBox(-5, 100, -45, 170);
         assertEquals(1, coverage.getHashLength());
         assertEquals(Sets.newHashSet("q", "r"), coverage.getHashes());
+    }
+
+    /**
+     * test copied from https://github.com/davidmoten/geo/pull/25/files to validate bug fix
+     */
+    @Test
+    public void testWideCoverage() {
+        double top = -1;
+        double left = -26;
+        double bottom = -2;
+        double right = 175;
+
+        Coverage coverage = GeoHash.coverBoundingBox(top, left, bottom, right, 1);
+        assertTrue(coverage.getHashes().contains("r"));
+    }
+
+    /**
+     * test copied from https://github.com/davidmoten/geo/issues/34 to validate bug fix
+     */
+    @Test
+    public void testCoverageAllWorld() {
+        double topLeftLat = 90d;
+        double topLeftLon = -179d;
+        double bottomRightLat = -90d;
+        double bottomRightLon = 180d;
+        Coverage coverage = GeoHash.coverBoundingBox(topLeftLat, topLeftLon, bottomRightLat, bottomRightLon, 1);
+        assertEquals(Sets.newHashSet("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "b", "c", "d", "e", "f", "g", "h", "j", "k", "m", "n", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"),
+                coverage.getHashes());
+    }
+
+    @Test
+    public void testCoverageAllWorldLeaflet() {
+        double topLeftLat = 90;
+        double topLeftLon = -703;
+        double bottomRightLat = -90;
+        double bottomRightLon = 624;
+        Coverage coverage = GeoHash.coverBoundingBox(topLeftLat, topLeftLon, bottomRightLat, bottomRightLon, 1);
+        assertEquals(Sets.newHashSet("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "b", "c", "d", "e", "f", "g", "h", "j", "k", "m", "n", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"),
+                coverage.getHashes());
+    }
+
+    @Test
+    public void testCoverageAntimeridianGoogleMaps() {
+        double topLeftLat = 39;
+        double topLeftLon = 156;
+        double bottomRightLat = 3;
+        double bottomRightLon = -118;
+        Coverage coverage = GeoHash.coverBoundingBox(topLeftLat, topLeftLon, bottomRightLat, bottomRightLon, 1);
+        assertEquals(Sets.newHashSet("x", "8", "9"), coverage.getHashes());
+    }
+
+    @Test
+    public void testCoverageAntimeridianLeaflet() {
+        double topLeftLat = 39;
+        double topLeftLon = -204;
+        double bottomRightLat = 2;
+        double bottomRightLon = -121;
+        Coverage coverage = GeoHash.coverBoundingBox(topLeftLat, topLeftLon, bottomRightLat, bottomRightLon, 1);
+        assertEquals(Sets.newHashSet("x", "8", "9"), coverage.getHashes());
+    }
+
+    @Test
+    public void testCoverageAntimeridianLeaflet2() {
+        double topLeftLat = 44;
+        double topLeftLon = 110;
+        double bottomRightLat = 9;
+        double bottomRightLon = 194;
+        Coverage coverage = GeoHash.coverBoundingBox(topLeftLat, topLeftLon, bottomRightLat, bottomRightLon, 1);
+        assertEquals(Sets.newHashSet("w", "x", "8"), coverage.getHashes());
+    }
+
+    @Test
+    public void testCoverageMaxHashes() {
+        double topLeftLat = 50.1112;
+        double topLeftLon = -6.8167;
+        double bottomRightLat = 46.6997;
+        double bottomRightLon = 3.7301;
+        Coverage coverage = GeoHash.coverBoundingBoxMaxHashes(topLeftLat, topLeftLon, bottomRightLat, bottomRightLon, 64);
+        assertEquals(3, coverage.getHashLength());
+        assertEquals(24, coverage.getHashes().size());
     }
 }

--- a/geo/src/test/java/com/github/davidmoten/geo/GeoHashTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/GeoHashTest.java
@@ -618,8 +618,4 @@ public class GeoHashTest {
         GeoHash.coverBoundingBox(0, 100, 10, 120);
     }
     
-    @Test(expected=IllegalArgumentException.class)
-    public void testCoverBoundingBoxPreconditionLon() {
-        GeoHash.coverBoundingBox(10, 120, 0, 100);
-    }
 }


### PR DESCRIPTION
We cannot use `GeoHash.coverBoundingBox` method with a bounding box around antimeridian (180/-180) because it does not allow bottomRightLon to be lower than topLeftLon (Google Maps behavior) or it does not handle correctly longitude outside [-180, 180] range (Leaflet behavior).

This pull request addresses this use case and also fixes issues in #25 and #34.

Now the `GeoHash.coverBoundingBoxLongs`  method allow more longitudes values in input. For instance, these values are accepted (see unit tests):
- topLeftLon = 156 and bottomRightLon = -118
- topLeftLon = -204 and bottomRightLon = -121
- topLeftLon = -703 and bottomRightLon = 624
