### PR TITLE
Add hashcode and equals methods to LatLong

### DIFF
--- a/geo/src/main/java/com/github/davidmoten/geo/LatLong.java
+++ b/geo/src/main/java/com/github/davidmoten/geo/LatLong.java
@@ -1,7 +1,5 @@
 package com.github.davidmoten.geo;
 
-import java.util.Objects;
-
 /**
  * A lat, long pair (WGS84). Immutable.
  * 
@@ -77,7 +75,7 @@ public class LatLong {
 
     @Override
     public int hashCode() {
-        return Objects.hash(lat, lon);
+        return 31 * Double.hashCode(lat) + Double.hashCode(lon);
     }
 
 }

--- a/geo/src/main/java/com/github/davidmoten/geo/LatLong.java
+++ b/geo/src/main/java/com/github/davidmoten/geo/LatLong.java
@@ -1,5 +1,7 @@
 package com.github.davidmoten.geo;
 
+import java.util.Objects;
+
 /**
  * A lat, long pair (WGS84). Immutable.
  * 
@@ -59,6 +61,23 @@ public class LatLong {
         builder.append(lon);
         builder.append("]");
         return builder.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final LatLong latLong = (LatLong) o;
+        return Double.compare(lat, latLong.lat) == 0 && Double.compare(lon, latLong.lon) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lat, lon);
     }
 
 }

--- a/geo/src/test/java/com/github/davidmoten/geo/LatLongTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/LatLongTest.java
@@ -1,8 +1,8 @@
 package com.github.davidmoten.geo;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Unit tests for {@link LatLong}.
@@ -16,6 +16,17 @@ public class LatLongTest {
     public void testToString() {
         assertEquals("LatLong [lat=10.0, lon=20.0]",
                 new LatLong(10, 20).toString());
+    }
+
+    @Test
+    public void testHashCode() {
+        float lat = 20.05f;
+        float lon = -15.5f;
+        LatLong a = new LatLong(lat, lon);
+        LatLong b = new LatLong(lat, lon);
+
+        assertEquals(a.hashCode(), b.hashCode());
+        assertEquals(a, b);
     }
 
 }


### PR DESCRIPTION
Discovered that LatLong doesn't actually implement hashcode() or equals(), so we can't actually put it into a Set<> or call distinct() on it in a stream.

Used IntelliJ IDEA's automatic generation of these things. Happy to change the implementation if desired.