### PR TITLE
Migrating to junit5

### DIFF
--- a/geo-mem/pom.xml
+++ b/geo-mem/pom.xml
@@ -26,9 +26,9 @@
 		</dependency>
 		<!-- Test Dependencies -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.11.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/geo-mem/src/test/java/com/github/davidmoten/geo/mem/GeomemTest.java
+++ b/geo-mem/src/test/java/com/github/davidmoten/geo/mem/GeomemTest.java
@@ -1,17 +1,13 @@
 package com.github.davidmoten.geo.mem;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 import java.util.UUID;
-
-import org.junit.Test;
-
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GeomemTest {
 
@@ -118,7 +114,7 @@ public class GeomemTest {
     /**
      * Indicates 4.5MB per 1000 records. Thus one million entries needs 4500
      * entries.
-     * 
+     *
      * @throws InterruptedException
      */
     @Test

--- a/geo/pom.xml
+++ b/geo/pom.xml
@@ -27,9 +27,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/geo/src/test/java/com/github/davidmoten/geo/Base32Test.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/Base32Test.java
@@ -2,10 +2,11 @@ package com.github.davidmoten.geo;
 
 import static com.github.davidmoten.geo.Base32.decodeBase32;
 import static com.github.davidmoten.geo.Base32.encodeBase32;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
 
+import org.junit.jupiter.api.Test;
 /**
  * Unit tests for {@link Base32}.
  * 
@@ -66,9 +67,9 @@ public class Base32Test {
 		assertEquals("00000000003v", encodeBase32(123));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testGetCharIndexThrowsExceptionWhenNonBase32CharacterGiven() {
-		Base32.getCharIndex('?');
+		assertThrows(IllegalArgumentException.class, () -> Base32.getCharIndex('?'));
 	}
 
 	@Test

--- a/geo/src/test/java/com/github/davidmoten/geo/CoverageLongsTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/CoverageLongsTest.java
@@ -1,8 +1,7 @@
 package com.github.davidmoten.geo;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link CoverageLongs}.

--- a/geo/src/test/java/com/github/davidmoten/geo/CoverageTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/CoverageTest.java
@@ -1,11 +1,10 @@
 package com.github.davidmoten.geo;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
 import com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link Coverage}.

--- a/geo/src/test/java/com/github/davidmoten/geo/DirectionTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/DirectionTest.java
@@ -1,8 +1,8 @@
 package com.github.davidmoten.geo;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for {@link Direction}.

--- a/geo/src/test/java/com/github/davidmoten/geo/GeoHashTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/GeoHashTest.java
@@ -197,7 +197,7 @@ public class GeoHashTest {
         assertEquals(0, point.getLon(), PRECISION);
     }
 
-    @Test
+//    @Test
     public void testSpeed() {
         long t = System.currentTimeMillis();
         int numIterations = 10000;

--- a/geo/src/test/java/com/github/davidmoten/geo/GeoHashTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/GeoHashTest.java
@@ -14,10 +14,7 @@ import static com.github.davidmoten.geo.GeoHash.neighbours;
 import static com.github.davidmoten.geo.GeoHash.right;
 import static com.github.davidmoten.geo.GeoHash.top;
 import static com.github.davidmoten.geo.GeoHash.widthDegrees;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,9 +22,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.junit.Test;
-
 import com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link GeoHash}.
@@ -62,14 +58,14 @@ public class GeoHashTest {
         assertEquals(0x65c0000000000002L, GeoHash.encodeHashToLong(41.842967, -72.727175, 2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void fromLongToStringInvalid() {
-        GeoHash.fromLongToString(0xff);
+        assertThrows(IllegalArgumentException.class, () -> GeoHash.fromLongToString(0xff));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void fromLongToStringZero() {
-        GeoHash.fromLongToString(0);
+        assertThrows(IllegalArgumentException.class, () -> GeoHash.fromLongToString(0));
     }
 
     @Test
@@ -100,25 +96,25 @@ public class GeoHashTest {
     public void testHashOfNonDefaultLength() {
         assertEquals("6gkzwg", encodeHash(-25.382708, -49.265506, 6));
     }
-    
+
     @Test
     public void testHashOfLength12() {
         assertEquals("6gkzwgjzn820", encodeHash(-25.382708, -49.265506, 12));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testHashOfLength13() {
-        encodeHash(-25.382708, -49.265506, 13);
+        assertThrows(IllegalArgumentException.class, () -> encodeHash(-25.382708, -49.265506, 13));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testHashOfLength20() {
-        encodeHash(-25.382708, -49.265506, 20);
+        assertThrows(IllegalArgumentException.class, () -> encodeHash(-25.382708, -49.265506, 20));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testHashEncodeGivenNonPositiveLength() {
-        encodeHash(-25.382708, -49.265506, 0);
+        assertThrows(IllegalArgumentException.class, () -> encodeHash(-25.382708, -49.265506, 0));
     }
 
     @Test
@@ -126,24 +122,24 @@ public class GeoHashTest {
         assertEquals("sew1c2vs2q5r", encodeHash(20, 31));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEncodeHashWithLatTooBig() {
-        encodeHash(1000, 100, 4);
+        assertThrows(IllegalArgumentException.class, () -> encodeHash(1000, 100, 4));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEncodeHashWithLatTooSmall() {
-        encodeHash(-1000, 100, 4);
+        assertThrows(IllegalArgumentException.class, () -> encodeHash(-1000, 100, 4));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAdjacentHashThrowsExceptionGivenNullHash() {
-        GeoHash.adjacentHash(null, Direction.RIGHT);
+        assertThrows(IllegalArgumentException.class, () -> GeoHash.adjacentHash(null, Direction.RIGHT));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAdjacentHashThrowsExceptionGivenBlankHash() {
-        GeoHash.adjacentHash("", Direction.RIGHT);
+        assertThrows(IllegalArgumentException.class, () -> GeoHash.adjacentHash("", Direction.RIGHT));
     }
 
     @Test
@@ -201,7 +197,7 @@ public class GeoHashTest {
         assertEquals(0, point.getLon(), PRECISION);
     }
 
-//    @Test
+    @Test
     public void testSpeed() {
         long t = System.currentTimeMillis();
         int numIterations = 10000;
@@ -404,10 +400,12 @@ public class GeoHashTest {
         assertEquals(Sets.newHashSet("dr7", "dre", "drk", "drs"), hashes);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCoverBoundingBoxWithZeroLengthThrowsException() {
-        coverBoundingBox(SCHENECTADY_LAT, SCHENECTADY_LON, HARTFORD_LAT,
-                HARTFORD_LON, 0);
+        assertThrows(IllegalArgumentException.class, () ->
+                coverBoundingBox(SCHENECTADY_LAT, SCHENECTADY_LON, HARTFORD_LAT,
+                        HARTFORD_LON, 0)
+        );
     }
     
     @Test
@@ -612,10 +610,10 @@ public class GeoHashTest {
         assertEquals("2pbpbpbpbpbr", neighbors.get(I_RIGHT_BOT));
     }
 
-    
-    @Test(expected=IllegalArgumentException.class)
+
+    @Test
     public void testCoverBoundingBoxPreconditionLat() {
-        GeoHash.coverBoundingBox(0, 100, 10, 120);
+        assertThrows(IllegalArgumentException.class, () -> GeoHash.coverBoundingBox(0, 100, 10, 120));
     }
     
 }

--- a/geo/src/test/java/com/github/davidmoten/geo/LatLongTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/LatLongTest.java
@@ -1,8 +1,8 @@
 package com.github.davidmoten.geo;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for {@link LatLong}.

--- a/geo/src/test/java/com/github/davidmoten/geo/TestingUtil.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/TestingUtil.java
@@ -5,6 +5,8 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Utility methods for unit tests.
  * 
@@ -20,10 +22,26 @@ public class TestingUtil {
      * @param cls
      */
     public static <T> void callConstructorAndCheckIsPrivate(Class<T> cls) {
-
+        Constructor<T> constructor;
+        try {
+            constructor = cls.getDeclaredConstructor();
+        } catch (NoSuchMethodException e1) {
+            throw new RuntimeException(e1);
+        } catch (SecurityException e1) {
+            throw new RuntimeException(e1);
+        }
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        constructor.setAccessible(true);
+        try {
+            constructor.newInstance();
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
     }
-
-    private static void assertTrue(boolean aPrivate) {
-    }
-
 }

--- a/geo/src/test/java/com/github/davidmoten/geo/TestingUtil.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/TestingUtil.java
@@ -1,6 +1,5 @@
 package com.github.davidmoten.geo;
 
-import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -17,31 +16,14 @@ public class TestingUtil {
     /**
      * Checks that a class has a no-argument private constructor and calls that
      * constructor to instantiate the class.
-     * 
+     *
      * @param cls
      */
     public static <T> void callConstructorAndCheckIsPrivate(Class<T> cls) {
-        Constructor<T> constructor;
-        try {
-            constructor = cls.getDeclaredConstructor();
-        } catch (NoSuchMethodException e1) {
-            throw new RuntimeException(e1);
-        } catch (SecurityException e1) {
-            throw new RuntimeException(e1);
-        }
-        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
-        constructor.setAccessible(true);
-        try {
-            constructor.newInstance();
-        } catch (InstantiationException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalArgumentException e) {
-            throw new RuntimeException(e);
-        } catch (InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
+
+    }
+
+    private static void assertTrue(boolean aPrivate) {
     }
 
 }

--- a/geo/src/test/java/com/github/davidmoten/geo/db/DatabaseTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/db/DatabaseTest.java
@@ -12,11 +12,11 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
 
 import com.github.davidmoten.geo.Coverage;
 import com.github.davidmoten.geo.GeoHash;
 import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
 
 /**
  * Displays benchmarks using geohashing with an H2 database.

--- a/geo/src/test/java/com/github/davidmoten/geo/util/PreconditionsTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/util/PreconditionsTest.java
@@ -1,6 +1,5 @@
 package com.github.davidmoten.geo.util;
 
-import com.github.davidmoten.geo.Base32;
 import com.github.davidmoten.geo.TestingUtil;
 import org.junit.jupiter.api.Test;
 

--- a/geo/src/test/java/com/github/davidmoten/geo/util/PreconditionsTest.java
+++ b/geo/src/test/java/com/github/davidmoten/geo/util/PreconditionsTest.java
@@ -1,8 +1,10 @@
 package com.github.davidmoten.geo.util;
 
-import org.junit.Test;
-
+import com.github.davidmoten.geo.Base32;
 import com.github.davidmoten.geo.TestingUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PreconditionsTest {
 
@@ -11,9 +13,9 @@ public class PreconditionsTest {
         TestingUtil.callConstructorAndCheckIsPrivate(Preconditions.class);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testCheckNotNullGivenNullThrowsException() {
-        Preconditions.checkNotNull(null, "message");
+        assertThrows(NullPointerException.class, () -> Preconditions.checkNotNull(null, "message"));
     }
 
 }


### PR DESCRIPTION
I tried to upgraded the code base to junit5 to get new features for unit testing. Below are the steps, I followed :
**Steps:**

1. Update the dependencies in pom.xml
2. Changing Packages

> org.junit.Test to org.junit.jupiter.api.Test
> org.junit.Assert.* to org.junit.jupiter.api.Assertions.*
3. When converting exception assertions from JUnit 4 to JUnit 5, the approach changes from using the @Test(expected = ...) annotation to using the assertThrows method in JUnit 5

<img width="1512" alt="Screenshot 2024-11-01 at 1 15 06 AM" src="https://github.com/user-attachments/assets/83e186b1-4eb0-47b9-a78a-26dcdb20a698">
